### PR TITLE
remove short array syntax

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ class SimplePOPCDN
         $this->cache_expire = (int) $cache_expire;
 
         // setup - see massive list of mimes below if you need to handle more
-        $this->setup([
+        $this->setup(array(
             'gif',    
             'jpg',    
             'png',    
@@ -44,7 +44,7 @@ class SimplePOPCDN
             'ttf',    
             'woff',    
             'woff2'    
-        ]);
+        ));
         
         // go...
         $this->handle();


### PR DESCRIPTION
The short array syntax was introduced in php 5.4 and I'm trying this on a 5.3 server.. had to switch the array declaration to not use the "short" syntax.